### PR TITLE
Added Quest, QuestMonster entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,19 +47,24 @@
 
     <dependency>
       <groupId>javax.inject</groupId>
-      <artifactId>inject-api</artifactId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
     </dependency>
 
     <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>persistence-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>hibernate</groupId>
+      <groupId>org.hibernate</groupId>
       <artifactId>hibernate</artifactId>
       <version>3.0.5</version>
+
+      <!-- This could not be found, apparently there are some license issues - we'll see if it's even needed. -->
+      <exclusions>  
+         <exclusion>  
+           <groupId>javax.transaction</groupId>  
+           <artifactId>jta</artifactId>  
+         </exclusion>  
+       </exclusions>
     </dependency>
+
     <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>

--- a/src/main/java/cz/muni/fi/pa165/heroes/entity/Quest.java
+++ b/src/main/java/cz/muni/fi/pa165/heroes/entity/Quest.java
@@ -1,35 +1,323 @@
 package cz.muni.fi.pa165.heroes.entity;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Enumerated;
+import javax.persistence.EnumType;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Entity for a Quest (a job posting for heroes).
+ *
+ * Quests have a name, location, a reward for heroes, and a limit of maximum
+ * heroes that may be assigned to it. Quests can be found in multiple states:
+ * NEW, ONGOING, FAILED, or SUCCESSFUL. (See {@link QuestState}.)
+ *
+ * NEW quests can be (re)assigned heroes and monsters, and can have their
+ * name, location, reward, and heroLimit modified.
+ *
+ * A quest becomes ONGOING either by calling its start() method, or when the
+ * maximum number of heroes are assigned to it.
+ *
+ * FAILED and SUCCESSFUL quests can be assigned a performance evaluation.
+ *
+ * @author Vojtech Krajnansky (423126)
+ */
 @Entity
 public class Quest {
 
+
+	// ATTRIBUTES
+
     @Id
+    @GeneratedValue
     private Long id;
 
     @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
     private String location;
+
+    @Column(nullable = false)
     private int reward;
+
+    @Column(nullable = false)
     private int heroLimit;
 
     @Enumerated(value = EnumType.ORDINAL)
     private QuestState state;
 
-    // TODO: add a relation to heroes
-    private List<Hero> assignedHeroes;
-    private List<Hero> deadHeroes;
-
-    @ManyToMany(targetEntity = Monster.class, fetch = FetchType.EAGER)
-    @JoinTable(
-            name = "quest_monster",
-            joinColumns = @JoinColumn(name = "quest_id", referencedColumnName = "id"),
-            inverseJoinColumns = @JoinColumn(name = "monster_id", referencedColumnName = "id")
-    )
-    private List<Monster> monsters;
     private int performanceEvaluation;
 
-    // TODO: Add accessors and mutators as you see fit
+    @OneToMany(targetEntity = Hero.class, fetch = FetchType.LAZY)
+    private List<Hero> assignedHeroes = new ArrayList<>();
+
+    @OneToMany(targetEntity = Hero.class, fetch = FetchType.LAZY)
+    private List<Hero> deadHeroes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "quest", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuestMonster> monsters = new ArrayList<>();
+
+
+    // CONSTRUCTORS
+
+    private Quest() {}
+
+    public Quest(String name, String location, int reward, int heroLimit) {
+        if (name == null) throw new IllegalArgumentException("Name of a quest can't be null");
+        if (location == null) throw new IllegalArgumentException("Location of a quest can't be null");
+        if (reward <= 0) throw new IllegalArgumentException("Reward of a quest must be a positive integer");
+        if (heroLimit <= 0) throw new IllegalArgumentException("HeroLimit of a quest must be a positive integer");
+
+        this.name = name;
+        this.location = location;
+        this.reward = reward;
+        this.heroLimit = heroLimit;
+
+        state = QuestState.NEW;
+    }
+
+
+    // PUBLIC METHODS
+
+    /**
+     * Assigns a new hero to the quest.
+     *
+     * If the hero is already assigned to the quest, ignores. If the
+     * assignment results in the hero limit being reached, starts the quest.
+     *
+     * @param hero The hero to assign to the quest.
+     *
+     * @exception IllegalStateException When called on a non-NEW quest.
+     */
+    public void addHero(Hero hero) {
+        if (state != QuestState.NEW) throw new IllegalStateException("Heroes can only be added to NEW quests");
+
+        if (!assignedHeroes.contains(hero)) {
+            assignedHeroes.add(hero);
+
+            if (assignedHeroes.size() == heroLimit) {
+                state = QuestState.ONGOING;
+            }
+        }
+    }
+
+    /**
+     * Assigns a new monster to the quest.
+     *
+     * If a monster of the same type is already assigned, increases the number
+     * of monsters of this type assigned to the quest by one.
+     *
+     * @param monster The monster type to add to the quest.
+     *
+     * @exception IllegalStateException When called on a non-NEW quest.
+     */
+    public void addMonster(Monster monster) {
+        if (state != QuestState.NEW) throw new IllegalStateException("Monsters can only be added to NEW quests");
+
+        QuestMonster questMonster = new QuestMonster(this, monster);
+
+        int index = monsters.indexOf(questMonster);
+        if (index == -1) {
+          throw new UnsupportedOperationException("Not implemented yet, waiting for monster::assignToQuest");
+          // TODO: Prepare monster so that it can add a questMonster to its quests list
+          // This can be uncommented when monster::assignToQuest has been implemented.
+          // monsters.add(questMonster);
+          // monster.assignToQuest(questMonster);			
+        } else {
+          monsters.get(index).increaseCount();
+        }
+    }
+
+    /**
+     * Removes a hero from the quest.
+     *
+     * If the hero has not been assigned to the quest, ignores.
+     *
+     * @param hero The hero to remove from this quest.
+     *
+     * @exception IllegalStateException When called on a non-NEW quest.
+     */
+    public void removeHero(Hero hero) {
+        if (state != QuestState.NEW) throw new IllegalStateException("Heroes can only be removed from NEW quests");
+
+        if (assignedHeroes.contains(hero)) {
+            assignedHeroes.remove(hero);
+        }
+    }
+
+    /**
+     * Removes a monster from the quest.
+     *
+     * If this monster type has not been assigned to the quest, ignores. If it
+     * has, removes one unit of this monster type from the quest. If the
+     * removed unit is the last of this type, removes this type from the quest
+     * completely.
+     *
+     * @param monster The monster type to remove from this quest.
+     *
+     * @exception IllegalStateException When called on a non-NEW quest.
+     */
+    public void removeMonster(Monster monster) {
+        if (state != QuestState.NEW) throw new IllegalStateException("Monsters can only be removed from NEW quests");
+
+        for (Iterator<QuestMonster> iter = monsters.iterator(); iter.hasNext(); ) {
+            QuestMonster questMonster = iter.next();
+
+            if (questMonster.getQuest().equals(this) && questMonster.getMonster().equals(monster)) {
+
+                if (questMonster.getMonsterCount() <= 0) {
+                    throw new UnsupportedOperationException("Not implemented, waiting for monster::removeFromQuest");
+                    // TODO: Prepare monster so that it can remove a questMonster from its quests list
+                    // This can be uncommented when monster::removeFromQuest has been implemented.
+                    // iter.remove();
+                    // questMonster.getMonster().removeFromQuest(questMonster);
+                    // questMonster.setQuest(null);
+                    // questMonster.setMonster(null);	
+                } else {
+                  questMonster.decreaseCount();
+                }
+
+                break;
+            }
+        }
+    }
+
+    /**
+     * Sets this quest's state to ONGOING.
+     *
+     * @exception IllegalStateException When called on a non-NEW quest.
+     */
+    public void start() {
+        if (state != QuestState.NEW) throw new IllegalStateException("Only NEW quests can be started");
+        state = QuestState.ONGOING;
+    }
+
+    // GETTERS AND SETTERS
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        if (name == null) throw new IllegalArgumentException("Name of a quest can't be null");
+        if (state != QuestState.NEW) throw new IllegalStateException("Only NEW quests can have their name changed");
+        this.name = name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        if (location == null) throw new IllegalArgumentException("Location of a quest can't be null");
+        if (state != QuestState.NEW) throw new IllegalStateException("Only NEW quests can have the location changed");
+        this.location = location;
+    }
+
+    public int getReward() {
+      return reward;
+    }
+
+    public void setReward(int reward) {
+        if (reward <= 0) throw new IllegalArgumentException("Reward of a quest must be a positive integer");
+        if (state != QuestState.NEW) throw new IllegalStateException("Only NEW quests can have their reward changed");
+        this.reward = reward;
+    }
+
+    public int getHeroLimit() {
+        return heroLimit;
+    }
+
+    public void setHeroLimit(int heroLimit) {
+        if (heroLimit <= 0) throw new IllegalArgumentException("HeroLimit of a quest must be a positive integer");
+        if (state != QuestState.NEW) throw new IllegalStateException("Only NEW quests can have their heroLimit changed");
+        this.heroLimit = heroLimit;
+    }
+
+    public QuestState getQuestState() {
+        return state;
+    }
+
+    public int getPerformanceEvaluation() {
+        return performanceEvaluation;
+    }
+
+    public void setPerformanceEvaluation(int performanceEvaluation) {
+        if (state == QuestState.NEW || state == QuestState.ONGOING) {
+            throw new IllegalStateException("Cannot set performance evaluation to NEW or ONGOING quests");
+        }
+
+        if (performanceEvaluation < 0 || performanceEvaluation > 10) {
+            throw new IllegalArgumentException("Performance evaluation must be an integer between 0 and 10 (incl.)");
+        }
+
+        this.performanceEvaluation = performanceEvaluation;
+    }
+
+    public List<Hero> getAssignedHeroes() {
+        return Collections.unmodifiableList(assignedHeroes);
+    }
+
+    public List<Hero> getDeadHeroes() {
+        return Collections.unmodifiableList(deadHeroes);
+    }
+
+    public List<QuestMonster> getMonsters() {
+        return Collections.unmodifiableList(monsters);
+    }
+
+
+    // EQUALS AND HASH
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || !(o instanceof Quest)) return false;
+
+        Quest other = (Quest) o;
+
+        if (!name.equals(other.getName())) return false;
+        if (!location.equals(other.getLocation())) return false;
+
+        if (reward != other.getReward()) return false;
+        if (heroLimit != other.getHeroLimit()) return false;
+        if (state != other.getQuestState()) return false;
+        if (performanceEvaluation != other.getPerformanceEvaluation()) return false;
+
+        if (!assignedHeroes.equals(other.getAssignedHeroes())) return false;
+        if (!deadHeroes.equals(other.getAssignedHeroes())) return false;
+        if (!monsters.equals(other.getMonsters())) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id.hashCode();
+        result = 11 * result + name.hashCode();
+        result = 11 * result + location.hashCode();
+        result = 11 * result + reward;
+        result = 11 * result + heroLimit;
+        result = 11 * result + state.hashCode();
+        result = 11 * result + performanceEvaluation;
+        result = 11 * result + assignedHeroes.hashCode();
+        result = 11 * result + deadHeroes.hashCode();
+        result = 11 * result + monsters.hashCode();
+        return result;
+    }
 }

--- a/src/main/java/cz/muni/fi/pa165/heroes/entity/QuestMonster.java
+++ b/src/main/java/cz/muni/fi/pa165/heroes/entity/QuestMonster.java
@@ -1,0 +1,198 @@
+package cz.muni.fi.pa165.heroes.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * Composite entity for the M-to-N relationship between {@link Quest} and {@link Monster}.
+ *
+ * This is needed because we need additional information about the number of
+ * monsters of given type present in the {@link Quest}, so a simple join table is not
+ * sufficient.
+ *
+ * @author Vojtech Krajnansky (423126)
+ */
+@Entity
+public class QuestMonster {
+
+
+    // ATTRIBUTES
+
+    @EmbeddedId
+    private QuestMonsterId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("questId")
+    private Quest quest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("monsterId")
+    private Monster monster;
+
+    @Column(nullable = false)
+    private int monsterCount;
+
+
+    // CONSTRUCTORS
+
+    private QuestMonster() {}
+
+    public QuestMonster(Quest quest, Monster monster) {
+        if (quest == null) throw new IllegalArgumentException("Quest can't be null");
+        if (monster == null) throw new IllegalArgumentException("Monster can't be null");
+
+        this.quest = quest;
+        this.monster = monster;
+        this.id = new QuestMonsterId(quest.getId(), monster.getId());
+
+        monsterCount = 1;
+    }
+
+    public QuestMonster(Quest quest, Monster monster, int monsterCount) {
+        if (quest == null) throw new IllegalArgumentException("Quest can't be null");
+        if (monster == null) throw new IllegalArgumentException("Monster can't be null");
+        if (monsterCount <= 0) throw new IllegalArgumentException("MonsterCount must be a positive integer");
+
+        this.quest = quest;
+        this.monster = monster;
+        this.id = new QuestMonsterId(quest.getId(), monster.getId());
+
+        this.monsterCount = monsterCount;
+    }
+
+
+    // PUBLLIC METHODS
+
+    /**
+     * Increases the count of monsters of this monster type in the quest.
+     */
+    public void increaseCount() {
+        monsterCount++;
+    }
+
+    /**
+     * Decreases the count of monsters of this monster type in the quest.
+     *
+     * This should only be called when monsterCount is positive.
+     *
+     * @exception IllegalStateException When called on QuestMonster with
+     *            monsterCount already 0.
+     */
+    public void decreaseCount() {
+        if (monsterCount == 0) throw new IllegalStateException("Cannot decrease count of monsters to negative integer");
+        monsterCount--;
+    }
+
+
+    // GETTERS AND SETTERS  
+
+    public Quest getQuest() {
+        return quest;
+    }
+
+    public void setQuest(Quest quest) {
+        this.quest = quest;
+    }
+
+    public Monster getMonster() {
+        return this.monster;
+    }
+
+    public void setMonster(Monster monster) {
+        this.monster = monster;
+    }
+
+    public int getMonsterCount() {
+        return monsterCount;
+    }
+
+
+    // EQUALS AND HASH
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof  QuestMonster)) return false;
+
+        QuestMonster other = (QuestMonster) o;
+        return Objects.equals(quest, other.quest)
+            && Objects.equals(monster, other.monster);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(quest, monster);
+    }
+
+
+    // NESTED CLASSES
+
+    /**
+     * Composite entity identifier for QuestMonster.
+     *
+     * @author Vojtech Krajnansky (423126)
+     */
+    @Embeddable
+    public static class QuestMonsterId implements Serializable {
+
+
+        // ATTRIBUTES
+
+        @Column(name = "quest_id")
+        private Long questId;
+
+        @Column(name = "monster_id")
+        private Long monsterId;
+
+
+        // CONSTRUCTORS
+
+        private QuestMonsterId() {}
+
+        public QuestMonsterId(Long questId, Long monsterId) {
+            if (questId == null) throw new IllegalArgumentException("QuestId can't be null");
+            if (monsterId == null) throw new IllegalArgumentException("MonsterId can't be null");
+
+            this.questId = questId;
+            this.monsterId = monsterId;
+        }
+
+        // GETTERS
+
+        public Long getQuestId() {
+            return questId;
+        }
+
+        public Long getMonsterId() {
+            return monsterId;
+        }
+
+
+        // EQUALS AND HASH
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || !(o instanceof  QuestMonsterId)) return false;
+
+            QuestMonsterId other = (QuestMonsterId) o;
+            return Objects.equals(questId, other.questId)
+                && Objects.equals(monsterId, other.monsterId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(questId, monsterId);
+        }
+    }
+}


### PR DESCRIPTION
Added:
- Quest entity (almost fully working - blocked by Monster - see TODOs in code)
- QuestMonster entity (for Quest<->Monster mappings with additional information about the count of the monsters of given type in the quest)

Is compilable, has most of the functionality required - currently, there is no way to change the state to SUCCESSFUL or FAILED, as I'd like to discuss that a little bit more.