### PR TITLE
Fixed persistence

### DIFF
--- a/hero-jobs.iml
+++ b/hero-jobs.iml
@@ -27,6 +27,10 @@
     <orderEntry type="library" name="Maven: javax.inject:inject-api:unknown" level="project" />
     <orderEntry type="library" name="Maven: javax.persistence:persistence-api:unknown" level="project" />
     <orderEntry type="library" name="Maven: javax.transaction:jta:1.0.1B" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-tx:5.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-orm:5.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-tx:5.1.0.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-orm:5.1.0.RELEASE" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.10.19" level="project" />

--- a/src/main/java/cz/muni/fi/pa165/App.java
+++ b/src/main/java/cz/muni/fi/pa165/App.java
@@ -1,20 +1,52 @@
 package cz.muni.fi.pa165;
 
+import cz.muni.fi.pa165.heroes.dao.MonsterDAO;
+import cz.muni.fi.pa165.heroes.dao.impl.JpaMonsterDAO;
+import cz.muni.fi.pa165.heroes.entity.Affinity;
+import cz.muni.fi.pa165.heroes.entity.Monster;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Hello world!
  *
  */
-public class App 
+public class App
 {
     public static void main( String[] args )
     {
-        new AnnotationConfigApplicationContext(InMemoryDatabaseSpring.class);
+        ApplicationContext context = new AnnotationConfigApplicationContext(InMemoryDatabaseSpring.class);
+
         EntityManagerFactory emf = Persistence.createEntityManagerFactory("development");
+        EntityManager em = emf.createEntityManager();
+        em.getTransaction().begin();
+
+        Affinity fire = new Affinity("Fire", 3);
+        em.persist(fire);
+
+        Affinity light = new Affinity("Light", 1);
+        em.persist(light);
+
+        Monster ogre = new Monster("Ogre", 150, 30, "medium", Arrays.asList(fire), Arrays.asList(light));
+        em.persist(ogre);
+
+        em.getTransaction().commit();
+        em.flush();
+        em.close();
+
+        MonsterDAO monsterDAO = context.getBean("jpaMonsterDAO", JpaMonsterDAO.class);
+        List<Monster> found = monsterDAO.findWithStrength(fire);
+        System.out.println(found);
+
+        em = emf.createEntityManager();
+        System.out.println(em.createQuery("SELECT m FROM Monster m").getResultList());
+        em.close();
 
         emf.close();
     }

--- a/src/main/java/cz/muni/fi/pa165/InMemoryDatabaseSpring.java
+++ b/src/main/java/cz/muni/fi/pa165/InMemoryDatabaseSpring.java
@@ -1,52 +1,37 @@
 package cz.muni.fi.pa165;
 
-import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.instrument.classloading.InstrumentationLoadTimeWeaver;
-import org.springframework.instrument.classloading.LoadTimeWeaver;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
-import org.springframework.orm.jpa.JpaTransactionManager;
-import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.orm.jpa.LocalEntityManagerFactoryBean;
 
 import javax.sql.DataSource;
 
 
 @Configuration
-@EnableTransactionManagement
-@EnableJpaRepositories
 @ComponentScan(basePackages = "cz.muni.fi.pa165.heroes")
+@EnableJpaRepositories("cz.muni.fi.pa165.heroes.dao")
 public class InMemoryDatabaseSpring {
 
     @Bean
-    public LoadTimeWeaver instrumentationLoadTimeWeaver() {
-        return new InstrumentationLoadTimeWeaver();
-    }
+    public LocalEntityManagerFactoryBean entityManagerFactoryBean() {
+        LocalEntityManagerFactoryBean factory = new LocalEntityManagerFactoryBean();
 
-    @Bean
-    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
-        LocalContainerEntityManagerFactoryBean jpaFactoryBean = new LocalContainerEntityManagerFactoryBean();
-        jpaFactoryBean.setDataSource(db());
-        jpaFactoryBean.setLoadTimeWeaver(instrumentationLoadTimeWeaver());
-        jpaFactoryBean.setPersistenceProviderClass(HibernatePersistenceProvider.class);
+        // To create the in-memory database
+        db();
 
-        return jpaFactoryBean;
-    }
-
-    @Bean
-    public JpaTransactionManager transactionManager() {
-        return new JpaTransactionManager();
+        factory.setPersistenceUnitName("development");
+        return factory;
     }
 
     @Bean
     public DataSource db() {
         EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder();
-        EmbeddedDatabase db = builder.setType(EmbeddedDatabaseType.DERBY).build();
+        EmbeddedDatabase db = builder.setType(EmbeddedDatabaseType.DERBY).ignoreFailedDrops(true).build();
         return db;
     }
 


### PR DESCRIPTION
This commit adds a fix to persistence layer, to make project runnable. Note the main() method where the dao is obtained as bean not instantiated using `new` keyword, as that keeps it within the same persistence context. The main still fails due to bug in Monster entity. The relation between Monster and affinities looks like this:     
```
create table Monster_Affinity (
       Monster_id bigint not null,
        weaknesses_id bigint not null,
        strengths_id bigint not null
    )
```
Which causes a strength to have a weakness id and vice versa (run main() to see the problem). @jstrmen have a look at this ASAP.